### PR TITLE
[Change] named export to default export under /pages/

### DIFF
--- a/pages/components/BreakMin.tsx
+++ b/pages/components/BreakMin.tsx
@@ -1,8 +1,9 @@
 import { useRecoilState } from "recoil";
 import { breakState } from "../../states/timerState";
-import { SetTime } from "./SetTime";
-export const BreakMin = () => {
+import SetTime from "./SetTime";
+const BreakMin = () => {
   const [min, setMin] = useRecoilState<number>(breakState);
 
   return <SetTime min={min} setMin={setMin} />;
 };
+export default BreakMin;

--- a/pages/components/Header.tsx
+++ b/pages/components/Header.tsx
@@ -1,10 +1,10 @@
 import { Heading } from "@chakra-ui/react";
-import { Dispatch, SetStateAction } from "react";
 
-export const Header = () => {
+const Header = () => {
   return (
     <Heading textAlign="center" as={"h6"}>
       Pomodoro Timer
     </Heading>
   );
 };
+export default Header;

--- a/pages/components/LongBreakMin.tsx
+++ b/pages/components/LongBreakMin.tsx
@@ -1,8 +1,9 @@
 import { useRecoilState } from "recoil";
 import { longBreakState } from "../../states/timerState";
-import { SetTime } from "./SetTime";
-export const LongBreakMin = () => {
+import SetTime from "./SetTime";
+const LongBreakMin = () => {
   const [min, setMin] = useRecoilState<number>(longBreakState);
 
   return <SetTime min={min} setMin={setMin} />;
 };
+export default LongBreakMin;

--- a/pages/components/MusicUpload.tsx
+++ b/pages/components/MusicUpload.tsx
@@ -8,7 +8,7 @@ import {
 import { IconButton, Input } from "@chakra-ui/react";
 import { FiFile } from "react-icons/fi";
 
-export const MusicUpload = () => {
+const MusicUpload = () => {
   const inputRef = useRef<any>(null);
   const setUsrMusic = useSetRecoilState<HTMLAudioElement | null>(usrMusicState);
   const setUsrMusicSrc = useSetRecoilState<string>(usrMusicSrcState);
@@ -62,3 +62,4 @@ export const MusicUpload = () => {
     </>
   );
 };
+export default MusicUpload;

--- a/pages/components/PomodoroMin.tsx
+++ b/pages/components/PomodoroMin.tsx
@@ -1,8 +1,9 @@
 import { useRecoilState } from "recoil";
 import { timerState } from "../../states/timerState";
-import { SetTime } from "./SetTime";
-export const PomodoroMin = () => {
+import SetTime from "./SetTime";
+const PomodoroMin = () => {
   const [min, setMin] = useRecoilState<number>(timerState);
 
   return <SetTime min={min} setMin={setMin} />;
 };
+export default PomodoroMin;

--- a/pages/components/SetTime.tsx
+++ b/pages/components/SetTime.tsx
@@ -9,7 +9,7 @@ type Props = {
   min: number;
   setMin: (num: number) => void;
 };
-export const SetTime = (props: Props) => {
+const SetTime = (props: Props) => {
   return (
     <NumberInput
       onChange={(dummy: string, num: number) => {
@@ -28,3 +28,4 @@ export const SetTime = (props: Props) => {
     </NumberInput>
   );
 };
+export default SetTime;

--- a/pages/components/Settings.tsx
+++ b/pages/components/Settings.tsx
@@ -13,13 +13,13 @@ import {
   Box,
   Grid,
 } from "@chakra-ui/react";
-import { PomodoroMin } from "./PomodoroMin";
-import { LongBreakMin } from "./LongBreakMin";
-import { BreakMin } from "./BreakMin";
+import PomodoroMin from "./PomodoroMin";
+import LongBreakMin from "./LongBreakMin";
+import BreakMin from "./BreakMin";
 
-import { Volume } from "./Volume";
-import { MusicUpload } from "./MusicUpload";
-export const Settings = () => {
+import Volume from "./Volume";
+import MusicUpload from "./MusicUpload";
+const Settings = () => {
   const { isOpen, onOpen, onClose } = useDisclosure();
 
   return (
@@ -63,3 +63,4 @@ export const Settings = () => {
     </>
   );
 };
+export default Settings;

--- a/pages/components/Timer.tsx
+++ b/pages/components/Timer.tsx
@@ -16,7 +16,7 @@ import {
   volumeState,
 } from "../../states/usrMusic";
 import { useInterval } from "@chakra-ui/hooks";
-export const Timer = () => {
+const Timer = () => {
   const minDuration = useRecoilValue<number>(timerState);
   const minBreak = useRecoilValue<number>(breakState);
   const minLongBreak = useRecoilValue<number>(longBreakState);
@@ -106,3 +106,4 @@ export const Timer = () => {
     </>
   );
 };
+export default Timer;

--- a/pages/components/Volume.tsx
+++ b/pages/components/Volume.tsx
@@ -11,7 +11,7 @@ import React, { useState } from "react";
 import { GoMute, GoUnmute } from "react-icons/go";
 import { useRecoilState } from "recoil";
 import { isMuteState, volumeState } from "../../states/usrMusic";
-export const Volume = () => {
+const Volume = () => {
   const [isMute, setIsMute] = useRecoilState<boolean>(isMuteState);
   const [volume, setVolume] = useRecoilState<number>(volumeState);
   const [prevVolume, setPrevVolume] = useState<number>(volume);
@@ -28,7 +28,9 @@ export const Volume = () => {
   };
   return (
     <>
-      <Box marginBottom="1" textAlign="center">Volume</Box>
+      <Box marginBottom="1" textAlign="center">
+        Volume
+      </Box>
       <Flex marginBottom="1" gridGap="5">
         <IconButton
           aria-label="Set Volume"
@@ -63,3 +65,4 @@ export const Volume = () => {
     </>
   );
 };
+export default Volume;


### PR DESCRIPTION
Because of
https://github.com/vercel/next.js/issues/7275
issue, named export is prohibited under /pages/
components.